### PR TITLE
Bump version number in RPM specs

### DIFF
--- a/tacacs+.spec
+++ b/tacacs+.spec
@@ -2,10 +2,10 @@ Summary: TACACS+ Daemon
 Name: tacacs+
 Group: Networking/Servers
 Version: FB4.0.4.19.1
-Release: 7fb
+Release: 8fb
 License: Cisco
 
-Packager: Cooper Lees <cooper@fb.com>
+Packager: David Rothera <drothera@fb.com>
 Vendor: Facebook Inc.
 
 Source: %{name}-%{version}.tar.gz

--- a/tacacs+6.spec
+++ b/tacacs+6.spec
@@ -2,10 +2,10 @@ Summary: TACACS+ Daemon
 Name: tacacs+6
 Group: Networking/Servers
 Version: FB4.0.4.19.1
-Release: 7fb
+Release: 8fb
 License: Cisco
 
-Packager: Cooper Lees <cooper@fb.com>
+Packager: David Rothera <drothera@fb.com>
 Vendor: Facebook Inc.
 
 Source: tacacs+-%{version}.tar.gz


### PR DESCRIPTION
Bump version number to take into account the changes made regarding init config for Centos