### PR TITLE
[RPM Specs] Ensure we have all deps

### DIFF
--- a/tacacs+.spec
+++ b/tacacs+.spec
@@ -13,7 +13,7 @@ Source: %{name}-%{version}.tar.gz
 BuildRoot: %{_tmppath}/%{name}-%{version}-%{release}-root
 
 BuildRequires: gcc, bison, flex, m4, pam-devel, tcp_wrappers, tcp_wrappers-devel, systemd
-Requires: pam, tcp_wrappers
+Requires: pam, tcp_wrappers, tcp_wrappers-devel, tcp_wrappers-libs
 
 %description
 IPv4 Tacacs+ Daemon for Linux

--- a/tacacs+6.spec
+++ b/tacacs+6.spec
@@ -13,7 +13,7 @@ Source: tacacs+-%{version}.tar.gz
 BuildRoot: %{_tmppath}/tacacs+-%{version}-%{release}-root
 
 BuildRequires: gcc, bison, flex, m4, pam-devel, tcp_wrappers, tcp_wrappers-devel, systemd
-Requires: pam, tcp_wrappers, tacacs+
+Requires: pam, tcp_wrappers, tcp_wrappers-devel, tcp_wrappers-libs, tacacs+
 
 %define _unpackaged_files_terminate_build 0
 


### PR DESCRIPTION
- SystemD could not start without both the libs and devel pacakges
  installed on C7. Adding to RPM spec so we don't forget next time and I
  don't spend time debugging the segfault :D

It now starts with SystemD on my test CentOS7 box.