### PR TITLE
Add python to the spec file build requirements

### DIFF
--- a/tacacs+.spec
+++ b/tacacs+.spec
@@ -12,7 +12,7 @@ Source: %{name}-%{version}.tar.gz
 
 BuildRoot: %{_tmppath}/%{name}-%{version}-%{release}-root
 
-BuildRequires: gcc, bison, flex, m4, pam-devel, tcp_wrappers, tcp_wrappers-devel, systemd
+BuildRequires: gcc, bison, flex, m4, pam-devel, tcp_wrappers, tcp_wrappers-devel, systemd, python
 Requires: pam, tcp_wrappers, tcp_wrappers-devel, tcp_wrappers-libs
 
 %description


### PR DESCRIPTION
Add python as a spec file requirement. Python is needed for rpmbuild to be able to run 'brp-python-bytecompile' and build .pyc and .pyo files.

Didn't run into this problem before since probably most target systems already include a python interpreter.