### PR TITLE
Add reloading support to service

### DIFF
--- a/tacacs-F4.0.4.28/tac_plus.service
+++ b/tacacs-F4.0.4.28/tac_plus.service
@@ -16,6 +16,8 @@ ExecStart=/usr/sbin/tac_plus \
   -C /etc/tac_plus.conf \
   -G
 
+ExecReload=/bin/kill -HUP $MAINPID
+
 Restart=always
 
 [Install]

--- a/tacacs-F4.0.4.28/tac_plus.sysvinit
+++ b/tacacs-F4.0.4.28/tac_plus.sysvinit
@@ -27,23 +27,29 @@ case "$1" in
         # Got Config File?
         [ -f /etc/tac_plus.conf ] || exit 69
 
-        echo -n $"Starting $prog: "
+        echo -n "Starting $prog: "
         daemon $TACPLUS_BIN -C $TACPLUS_CONF $TACPLUS_OPTS
         RETVAL=$?
         [ $RETVAL -eq 0 ] && touch /var/lock/subsys/$prog
         echo
         ;;
   stop)
-        echo -n $"Shutting down $prog: "
+        echo -n "Shutting down $prog: "
         killproc $prog
         RETVAL=$?
         [ $RETVAL -eq 0 ] && rm -f /var/lock/subsys/$prog
         echo
         ;;
-  restart|reload)
+  restart)
         $0 stop
         $0 start
         RETVAL=$?
+        ;;
+  reload)
+        echo -n "Reloading $prog: "
+        killproc $prog -HUP
+        RETVAL=$?
+        echo
         ;;
   status)
         status $prog


### PR DESCRIPTION
This adds ExecReload command to send the SIGHUP signal to the service.
This  should cause the service to reload the config instead of forcing a
restart on config changes.

Test on centos7:

```
[vagrant@localhost x86_64]$ sudo systemctl status tac_plus
● tac_plus.service - TACACS+ IPv4 Daemon
   Loaded: loaded (/usr/lib/systemd/system/tac_plus.service; enabled; vendor preset: disabled)
   Active: active (running) since Tue 2018-12-11 23:45:35 UTC; 9s ago
  Process: 25822 ExecStartPre=/usr/sbin/tac_plus -C /etc/tac_plus.conf -P (code=exited, status=0/SUCCESS)
 Main PID: 25823 (tac_plus)
   CGroup: /system.slice/tac_plus.service
           └─25823 /usr/sbin/tac_plus -C /etc/tac_plus.conf -G

Dec 11 23:45:35 localhost.localdomain systemd[1]: Starting TACACS+ IPv4 Daemon...
Dec 11 23:45:35 localhost.localdomain tac_plus[25822]: Reading config
Dec 11 23:45:35 localhost.localdomain tac_plus[25822]: Version F4.0.4.28-6fb Initialized 1
Dec 11 23:45:35 localhost.localdomain tac_plus[25823]: Reading config
Dec 11 23:45:35 localhost.localdomain systemd[1]: Started TACACS+ IPv4 Daemon.
Dec 11 23:45:35 localhost.localdomain tac_plus[25823]: Version F4.0.4.28-6fb Initialized 1
Dec 11 23:45:35 localhost.localdomain tac_plus[25823]: socket FD 4 AF 2
Dec 11 23:45:35 localhost.localdomain tac_plus[25823]: socket FD 5 AF 10
Dec 11 23:45:35 localhost.localdomain tac_plus[25823]: uid=0 euid=0 gid=0 egid=0 s=16707696
[vagrant@localhost x86_64]$ sudo systemctl reload tac_plus
[vagrant@localhost x86_64]$ sudo systemctl status tac_plus
● tac_plus.service - TACACS+ IPv4 Daemon
   Loaded: loaded (/usr/lib/systemd/system/tac_plus.service; enabled; vendor preset: disabled)
   Active: active (running) since Tue 2018-12-11 23:45:35 UTC; 24s ago
  Process: 25836 ExecReload=/bin/kill -HUP $MAINPID (code=exited, status=0/SUCCESS)
  Process: 25822 ExecStartPre=/usr/sbin/tac_plus -C /etc/tac_plus.conf -P (code=exited, status=0/SUCCESS)
 Main PID: 25823 (tac_plus)
   CGroup: /system.slice/tac_plus.service
           └─25823 /usr/sbin/tac_plus -C /etc/tac_plus.conf -G

Dec 11 23:45:35 localhost.localdomain tac_plus[25822]: Version F4.0.4.28-6fb Initialized 1
Dec 11 23:45:35 localhost.localdomain tac_plus[25823]: Reading config
Dec 11 23:45:35 localhost.localdomain systemd[1]: Started TACACS+ IPv4 Daemon.
Dec 11 23:45:35 localhost.localdomain tac_plus[25823]: Version F4.0.4.28-6fb Initialized 1
Dec 11 23:45:35 localhost.localdomain tac_plus[25823]: socket FD 4 AF 2
Dec 11 23:45:35 localhost.localdomain tac_plus[25823]: socket FD 5 AF 10
Dec 11 23:45:35 localhost.localdomain tac_plus[25823]: uid=0 euid=0 gid=0 egid=0 s=16707696
Dec 11 23:45:57 localhost.localdomain tac_plus[25823]: Reading config
Dec 11 23:45:57 localhost.localdomain systemd[1]: Reloaded TACACS+ IPv4 Daemon.
Dec 11 23:45:57 localhost.localdomain tac_plus[25823]: Version F4.0.4.28-6fb Initialized 2
[vagrant@localhost x86_64]$ sudo systemctl restart tac_plus
[vagrant@localhost x86_64]$ sudo systemctl status tac_plus
● tac_plus.service - TACACS+ IPv4 Daemon
   Loaded: loaded (/usr/lib/systemd/system/tac_plus.service; enabled; vendor preset: disabled)
   Active: active (running) since Tue 2018-12-11 23:46:16 UTC; 1s ago
  Process: 25836 ExecReload=/bin/kill -HUP $MAINPID (code=exited, status=0/SUCCESS)
  Process: 25848 ExecStartPre=/usr/sbin/tac_plus -C /etc/tac_plus.conf -P (code=exited, status=0/SUCCESS)
 Main PID: 25850 (tac_plus)
   CGroup: /system.slice/tac_plus.service
           └─25850 /usr/sbin/tac_plus -C /etc/tac_plus.conf -G

Dec 11 23:46:16 localhost.localdomain systemd[1]: Starting TACACS+ IPv4 Daemon...
Dec 11 23:46:16 localhost.localdomain tac_plus[25848]: Reading config
Dec 11 23:46:16 localhost.localdomain tac_plus[25848]: Version F4.0.4.28-6fb Initialized 1
Dec 11 23:46:16 localhost.localdomain systemd[1]: Started TACACS+ IPv4 Daemon.
Dec 11 23:46:16 localhost.localdomain tac_plus[25850]: Reading config
Dec 11 23:46:16 localhost.localdomain tac_plus[25850]: Version F4.0.4.28-6fb Initialized 1
Dec 11 23:46:16 localhost.localdomain tac_plus[25850]: socket FD 4 AF 2
Dec 11 23:46:16 localhost.localdomain tac_plus[25850]: socket FD 5 AF 10
Dec 11 23:46:16 localhost.localdomain tac_plus[25850]: uid=0 euid=0 gid=0 egid=0 s=14352496
```

sysvinit:
```
[vagrant@localhost init.d]$ sudo ./tac_plus start
Starting tac_plus:                                         [  OK  ]
[vagrant@localhost init.d]$ sudo ./tac_plus status
tac_plus (pid  7411) is running...
[vagrant@localhost init.d]$ sudo ./tac_plus reload
Reloading tac_plus:                                        [  OK  ]
[vagrant@localhost init.d]$ sudo ./tac_plus restart
Shutting down tac_plus:                                    [  OK  ]
Starting tac_plus:                                         [  OK  ]
[vagrant@localhost init.d]$ sudo ./tac_plus stop
Shutting down tac_plus:                                    [  OK  ]
[vagrant@localhost init.d]$ sudo cat /var/log/messages
Dec 12 00:09:19 localhost tac_plus[7409]: Reading config
Dec 12 00:09:19 localhost tac_plus[7409]: Version F4.0.4.28-6fb Initialized 1
Dec 12 00:09:30 localhost tac_plus[7411]: Reading config
Dec 12 00:09:30 localhost tac_plus[7411]: Version F4.0.4.28-6fb Initialized 2
Dec 12 00:09:33 localhost tac_plus[7411]: Received signal 15, shutting down
Dec 12 00:09:33 localhost tac_plus[7456]: Reading config
Dec 12 00:09:33 localhost tac_plus[7456]: Version F4.0.4.28-6fb Initialized 1
Dec 12 00:09:35 localhost tac_plus[7458]: Received signal 15, shutting down
```