### PR TITLE
Enable via PAM

### DIFF
--- a/tacacs-F4.0.4.28/config.c
+++ b/tacacs-F4.0.4.28/config.c
@@ -63,9 +63,16 @@
    <host_decl>		:=	host = <string> {
 					key = <string>
 					prompt = <string>
-					enable = aceclnt|cleartext|des|
+					enable = cleartext|des|
 						 file <filename/string>|
+#ifdef ACECLNT
+						 aceclnt|
+#endif
+#ifdef HAVE_PAM
+						 PAM |
+#endif
 						 nopassword|skey
+
 				}
 
    <user_decl>		:=	user = <string> {
@@ -1296,6 +1303,11 @@ parse_user(void)
 		    user->enable = tac_strdup(sym_buf);
 		    break;
 #endif
+#ifdef HAVE_PAM
+	    case S_pam:
+			user->enable = tac_strdup(sym_buf);
+			break;
+#endif
 
 		default:
 		    parse_error("expecting 'file', 'cleartext', 'nopassword', "
@@ -1304,6 +1316,9 @@ parse_user(void)
 #endif
 #ifdef ACECLNT
 				"'aceclnt', "
+#endif
+#ifdef HAVE_PAM
+				"'PAM', "
 #endif
 				"or 'des' keyword after 'enable =' on line %d",
 				sym_line);

--- a/tacacs-F4.0.4.28/pwlib.c
+++ b/tacacs-F4.0.4.28/pwlib.c
@@ -238,6 +238,18 @@ verify_pwd(char *username, char *passwd, struct authen_data *data,
 {
     char *p;
 
+#if HAVE_PAM
+    if (strcmp(cfg_passwd, "PAM") == 0) {
+	/* try to verify the password via PAM */
+	if (!pam_verify(username, passwd, data)) {
+	data->status = TAC_PLUS_AUTHEN_STATUS_FAIL;
+	return(0);
+	} else
+	data->status = TAC_PLUS_AUTHEN_STATUS_PASS;
+	return(data->status == TAC_PLUS_AUTHEN_STATUS_PASS);
+    }
+#endif
+
     /* Deal with the cfg_passwd depending on its type */
     p = tac_find_substring("cleartext ", cfg_passwd);
     if (p) {


### PR DESCRIPTION
Adds PAM support for user enable passwords (in case another method such as s/key or aceclnt is being used for login password)