### PR TITLE
support enable pre authorization check

### DIFF
--- a/tacacs-F4.0.4.28/parse.h
+++ b/tacacs-F4.0.4.28/parse.h
@@ -98,3 +98,6 @@
 #define S_writetimeout 55
 #define S_accepttimeout 56
 #define S_logauthor 57
+#ifdef UENABLE
+#define S_beforeenable 58
+#endif

--- a/tacacs-F4.0.4.28/tac_plus.h
+++ b/tacacs-F4.0.4.28/tac_plus.h
@@ -464,6 +464,7 @@ int	keycode(char *);
 void	parser_init(void);
 
 /* programs.c */
+int call_pre_enable(char *, struct authen_data *, char *, int);
 int call_pre_process(char *, struct author_data *, char ***, int *, char *,
 		     int);
 int call_post_process(char *, struct author_data *, char ***, int *);


### PR DESCRIPTION
allows for using an external script (do_auth.py) to perform pre-enable checks (without relying on command authorization on the remote device).

same semantics as before/after authorization, except it ignores AV pairs (so the 2/3 retvals don't really do much different from 0/1)