### PR TITLE
Add specifier to LOG func

### DIFF
--- a/tacacs-F4.0.4.28/packet.c
+++ b/tacacs-F4.0.4.28/packet.c
@@ -59,7 +59,7 @@ get_authen_continue(void)
 		     "when expecting authentication cont", session.peer,
 		     hdr->type, hdr->seq_no) == -1)
 	    strcpy(msg, "");
-	report(LOG_ERR, msg);
+	report(LOG_ERR, "%s", msg);
 	send_authen_error(msg);
 	return(NULL);
     }


### PR DESCRIPTION
report() uses vsprintf to format the log message (so you can do something like report(LOG_ERR, "test: %s", astring)). This means that msg here is the format string. If any piece of msg is user controlled, they can inject specifiers like %x to leak memory content, but it just goes into the logs.
