### PR TITLE
[tacplus] add input validation for remote-addr field

### DIFF
--- a/tacacs-F4.0.4.28/programs.c
+++ b/tacacs-F4.0.4.28/programs.c
@@ -127,6 +127,7 @@ lookup(char *sym, struct author_data *data)
     return(tac_strdup("unknown"));
 }
 
+
 /* is_valid_name performs input santization for fields that we think would be
 alphanumeric i.e NAC address field, username
 For NAC Address field, this value could refer to an IP address,
@@ -174,41 +175,41 @@ substitute(char *string, struct author_data *data)
     outp = out;
 
     while (*cp) {
-        if (*cp != DOLLARSIGN) {
-            *outp++ = *cp++;
-            continue;
-        }
-        cp++;			/* skip dollar sign */
-        symp = sym;
+	if (*cp != DOLLARSIGN) {
+	    *outp++ = *cp++;
+	    continue;
+	}
+	cp++;			/* skip dollar sign */
+	symp = sym;
 
-        /* does it have curly braces e.g. ${foo} ? */
-        if (*cp == '{') {
-            cp++;		/* skip { */
-            while (*cp && *cp != '}')
-            *symp++ = *cp++;
-            cp++;		/* skip } */
+	/* does it have curly braces e.g. ${foo} ? */
+	if (*cp == '{') {
+	    cp++;		/* skip { */
+	    while (*cp && *cp != '}')
+		*symp++ = *cp++;
+	    cp++;		/* skip } */
 
-        } else {
-            /* copy symbol into sym */
-            while (*cp && isalpha((int) *cp))
-            *symp++ = *cp++;
-        }
+	} else {
+	    /* copy symbol into sym */
+	    while (*cp && isalpha((int) *cp))
+		*symp++ = *cp++;
+	}
 
-        *symp = '\0';
-        /* lookup value */
+	*symp = '\0';
+	/* lookup value */
 
-        if (debug & DEBUG_SUBST_FLAG)
-            report(LOG_DEBUG, "Lookup %s", sym);
+	if (debug & DEBUG_SUBST_FLAG)
+	    report(LOG_DEBUG, "Lookup %s", sym);
 
-        valuep = value = lookup(sym, data);
+	valuep = value = lookup(sym, data);
 
-        if (debug & DEBUG_SUBST_FLAG)
-            report(LOG_DEBUG, "Expands to: %s", value);
+	if (debug & DEBUG_SUBST_FLAG)
+	    report(LOG_DEBUG, "Expands to: %s", value);
 
-        /* copy value into output */
-        while (valuep && *valuep)
-            *outp++ = *valuep++;
-        free(value);
+	/* copy value into output */
+	while (valuep && *valuep)
+	    *outp++ = *valuep++;
+	free(value);
     }
     *outp++ = '\0';
 

--- a/tacacs-F4.0.4.28/programs.c
+++ b/tacacs-F4.0.4.28/programs.c
@@ -83,7 +83,7 @@ lookup(char *sym, struct author_data *data)
     }
 
     if (STREQ(sym, "ip")) {
-        if (is_valid_name(data->id->NAS_ip)) {
+        if (is_valid_ip(data->id->NAS_ip)) {
             return(tac_strdup(data->id->NAS_ip));
         }
     }
@@ -145,11 +145,12 @@ static int is_valid_name(const char *name) {
         return 0;
     }
 
+
     // Character set check
     for (size_t i = 0; i < len; i++) {
         char c = name[i];
-        if (!isalnum(c) && c != '_' && c != '.') {
-            report(LOG_DEBUG, "invalid character=%c", c);
+        if (!isalnum(c) && c != '_' && c != '.' && c != ':') {
+            report(LOG_DEBUG, "invalid character '%c' inside field [%s]", c, name);
             return 0;
         }
     }
@@ -159,7 +160,7 @@ static int is_valid_name(const char *name) {
 
 /* is_valid_ip performs a very basic input sanitization for ip addresses */
 static int is_valid_ip(const char *address) {
-    size_t len = strlen(address)
+    size_t len = strlen(address);
 
     if (len > 100) {
         report(LOG_DEBUG, "field %s is longer than allowed length 100", address);
@@ -168,8 +169,8 @@ static int is_valid_ip(const char *address) {
     // Character set check
     for (size_t i = 0; i < len; i++) {
         char c = address[i];
-        if (!isalnum(c) && c != '.' && c != ":") {
-            report(LOG_DEBUG, "invalid character=%c", address[i]);
+        if (!isalnum(c) && c != '.' && c != ':') {
+            report(LOG_DEBUG, "invalid character %c found inside field [%s]", c, address);
             return 0;
         }
     }
@@ -230,7 +231,7 @@ substitute(char *string, struct author_data *data)
 	/* copy value into output */
 	while (valuep && *valuep)
 	    *outp++ = *valuep++;
-	free(value);
+	    free(value);
     }
     *outp++ = '\0';
 

--- a/tacacs-F4.0.4.28/programs.c
+++ b/tacacs-F4.0.4.28/programs.c
@@ -31,7 +31,6 @@
 #include <signal.h>
 
 static void close_fds(int, int, int);
-static int is_valid_ip(const char *address);
 static int is_valid_name(const char *name);
 static char *lookup(char *, struct author_data *);
 #if HAVE_PID_T
@@ -83,9 +82,7 @@ lookup(char *sym, struct author_data *data)
     }
 
     if (STREQ(sym, "ip")) {
-        if (is_valid_ip(data->id->NAS_ip)) {
-            return(tac_strdup(data->id->NAS_ip));
-        }
+        return(tac_strdup(data->id->NAS_ip));
     }
 
     if (STREQ(sym, "port")) {
@@ -151,26 +148,6 @@ static int is_valid_name(const char *name) {
         char c = name[i];
         if (!isalnum(c) && c != '_' && c != '.' && c != ':') {
             report(LOG_DEBUG, "invalid character '%c' inside field [%s]", c, name);
-            return 0;
-        }
-    }
-
-    return 1; // true
-}
-
-/* is_valid_ip performs a very basic input sanitization for ip addresses */
-static int is_valid_ip(const char *address) {
-    size_t len = strlen(address);
-
-    if (len > 100) {
-        report(LOG_DEBUG, "field %s is longer than allowed length 100", address);
-        return 0;
-    }
-    // Character set check
-    for (size_t i = 0; i < len; i++) {
-        char c = address[i];
-        if (!isalnum(c) && c != '.' && c != ':') {
-            report(LOG_DEBUG, "invalid character %c found inside field [%s]", c, address);
             return 0;
         }
     }

--- a/tacacs-F4.0.4.28/programs.c
+++ b/tacacs-F4.0.4.28/programs.c
@@ -174,41 +174,41 @@ substitute(char *string, struct author_data *data)
     outp = out;
 
     while (*cp) {
-	if (*cp != DOLLARSIGN) {
-	    *outp++ = *cp++;
-	    continue;
-	}
-	cp++;			/* skip dollar sign */
-	symp = sym;
+        if (*cp != DOLLARSIGN) {
+            *outp++ = *cp++;
+            continue;
+        }
+        cp++;			/* skip dollar sign */
+        symp = sym;
 
-	/* does it have curly braces e.g. ${foo} ? */
-	if (*cp == '{') {
-	    cp++;		/* skip { */
-	    while (*cp && *cp != '}')
-		*symp++ = *cp++;
-	    cp++;		/* skip } */
+        /* does it have curly braces e.g. ${foo} ? */
+        if (*cp == '{') {
+            cp++;		/* skip { */
+            while (*cp && *cp != '}')
+            *symp++ = *cp++;
+            cp++;		/* skip } */
 
-	} else {
-	    /* copy symbol into sym */
-	    while (*cp && isalpha((int) *cp))
-		*symp++ = *cp++;
-	}
+        } else {
+            /* copy symbol into sym */
+            while (*cp && isalpha((int) *cp))
+            *symp++ = *cp++;
+        }
 
-	*symp = '\0';
-	/* lookup value */
+        *symp = '\0';
+        /* lookup value */
 
-	if (debug & DEBUG_SUBST_FLAG)
-	    report(LOG_DEBUG, "Lookup %s", sym);
+        if (debug & DEBUG_SUBST_FLAG)
+            report(LOG_DEBUG, "Lookup %s", sym);
 
-	valuep = value = lookup(sym, data);
+        valuep = value = lookup(sym, data);
 
-	if (debug & DEBUG_SUBST_FLAG)
-	    report(LOG_DEBUG, "Expands to: %s", value);
+        if (debug & DEBUG_SUBST_FLAG)
+            report(LOG_DEBUG, "Expands to: %s", value);
 
-	/* copy value into output */
-	while (valuep && *valuep)
-	    *outp++ = *valuep++;
-	    free(value);
+        /* copy value into output */
+        while (valuep && *valuep)
+            *outp++ = *valuep++;
+        free(value);
     }
     *outp++ = '\0';
 


### PR DESCRIPTION
this diff fixes a RCE vulnerability within the tacplus code.  The rem-addr field injectable through a tacacs client can be used to run a bash script on the host, under certain conditions a) the user config should have a before authorization directive, and a service should be specified. 
This fix treats rem-addr field to be a alphanumeric string, and it's values are generally IP addresses, hostnames, or vendor specific strings such as Local/Infinode. 
This fix will return value "unknown" if the rem-addr field consists of non alphanumeric characters. The treatment of this string is left to the remote system being called by tac_plus (to accept/reject)

Test plan 
./configure --without-libwrap
make
LD_LIBRARY_PATH=.libs. libs/tac_plus ./tac_plus -G -d 5 -l /dev/stdout -p 4949 -C tac_plus.cfg

<generate request through local client with rem-addr field set to different values>

Outputs - 
Before
```
Mon May 22 17:26:00 2023 [1780828]: Before authorization call: /usr/local/sbin/tac_policy -- '$user' '$address'
Mon May 22 17:26:00 2023 [1780828]: substitute: /usr/local/sbin/tac_policy -- '$user' '$address'
Mon May 22 17:26:00 2023 [1780828]: Dollar substitution: /usr/local/sbin/tac_policy -- 'DEFAULT' 'asd';bash -i >& echo 'hello''
Mon May 22 17:26:00 2023 [1780828]: input service=exec
```

After
```
Mon May 22 17:28:14 2023 [1802525]: Before authorization call: /usr/local/sbin/tac_policy -- '$user' '$address'
Mon May 22 17:28:14 2023 [1802525]: substitute: /usr/local/sbin/tac_policy -- '$user' '$address'
Mon May 22 17:28:14 2023 [1802525]: invalid character='
Mon May 22 17:28:14 2023 [1802525]: Dollar substitution: /usr/local/sbin/tac_policy -- 'DEFAULT' 'unknown'
Mon May 22 17:28:14 2023 [1802525]: input service=exec
Mon May 22 17:28:14 2023 [1802525]: Error Error from program (66): "sh: line 1: /usr/local/sbin/tac_policy: No such file or directory
"
Mon May 22 17:28:14 2023 [1802525]: pid 1802527 child exited status 127
Mon May 22 17:28:14 2023 [1802525]: cmd /usr/local/sbin/tac_policy -- '$user' '$address' returns 127 (unrecognised value)
Mon May 22 17:28:14 2023 [1802525]: authorization query for 'DEFAULT' tty0 from ::1 rejected
```
