### PR TITLE
licensing is MIT per the LICENSE file, not BSD

### DIFF
--- a/README.debian
+++ b/README.debian
@@ -22,4 +22,4 @@ Enjoy, and thanks to the facebook guys for the changes that they made
 here :-)
 
 ## License
-tac_plus is BSD licensed, as found in the LICENSE file.
+tac_plus is MIT licensed, as found in the LICENSE file.


### PR DESCRIPTION
Minor edit to the README.debian file calling out the license in use.