### PR TITLE
bypass c99 error

### DIFF
--- a/tacacs-F4.0.4.28/programs.c
+++ b/tacacs-F4.0.4.28/programs.c
@@ -135,7 +135,8 @@ static int is_valid_name(const char *name) {
     }
 
     // character set check
-    for (size_t i = 0; i < len; i++) {
+    size_t i;
+    for (i = 0; i < len; i++) {
        char c = name[i];
        if (!isalnum(c) && c != '_' && c != '.' && c != ':') {
           report(LOG_DEBUG, "invalid character '%c' inside field [%s]", c, name);


### PR DESCRIPTION
My RHEL7 environment barfs on compile b/c of the for loop init declaration. 

As usual SO had a [quick fix](https://stackoverflow.com/questions/29338206/error-for-loop-initial-declarations-are-only-allowed-in-c99-mode) so included it in my fork.

I dont have a ton of test resources/time and this is low return so feel free to close/reject and I will keep local.

