### PR TITLE
Add hyphen support to is_valid_name validation

### DIFF
--- a/tacacs-F4.0.4.28/programs.c
+++ b/tacacs-F4.0.4.28/programs.c
@@ -137,7 +137,7 @@ static int is_valid_name(const char *name) {
     // character set check
     for (size_t i = 0; i < len; i++) {
        char c = name[i];
-       if (!isalnum(c) && c != '_' && c != '.' && c != ':') {
+       if (!isalnum(c) && c != '_' && c != '.' && c != ':' && c != '-') {
           report(LOG_DEBUG, "invalid character '%c' inside field [%s]", c, name);
           return 0;
        }


### PR DESCRIPTION
Addition to the changes in this [PR](https://github.com/facebook/tac_plus/commit/68ba2a19472da0a3de28c41b7a2e222438dca359) to add input validation.
As pointed out in this [issue](https://github.com/facebook/tac_plus/issues/50), we might have missed some character in the validator.
- Added hyphen (-) character to allowed character set in is_valid_name()
- This enables validation of common network device naming conventions
- Maintains security while supporting real-world use cases like 'router-01', 'switch-core'
- Updated character validation in programs.c for username, NAS name, and NAC address fields

Post this change, NAS name and usernames can contain alphanumeric characters and special characters in the set 
[
   "_", // underscore
   "-", // hyphen
   ":", // colon
   "."  // period
]